### PR TITLE
debogage en version responsive sur les boutons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -112,7 +112,12 @@ body {
     grid-gap: 10px;
   }
   .operator,
-  .number {
+  .number,
+  .equal,
+  .clear,
+  .return,
+  .percent,
+  .add-or-substract {
     font-size: 18px;
     padding: 18px;
     border-radius: 20px;


### PR DESCRIPTION
- En version mobile les boutons n'étaient pas à la bonne taille et débordaient du container. Je l'ai rectifié en ajoutant des règles css dans les media queries.